### PR TITLE
Deixa somente os moderadores de fato - FEMUG-SC

### DIFF
--- a/LISTA.md
+++ b/LISTA.md
@@ -81,8 +81,6 @@ Sede          : Florianópolis, SC
 Responsável   : Diogo Moretti
 Moderadores   : Diogo Moretti
                 Pedro Nauck
-                Luiz Henrique Estacio
-                Fernando Daciuk
 ```
 -----
 ## FEMUG-AM

--- a/femug-list.json
+++ b/femug-list.json
@@ -74,9 +74,7 @@
       "fundador": "Diogo Moretti",
       "moderadores": [
         "Diogo Moretti",
-        "Pedro Nauck",
-        "Luiz Henrique Estacio",
-        "Fernando Daciuk"
+        "Pedro Nauck"
       ]
     }],
     "FEMUG-AM": [{


### PR DESCRIPTION
Deixando somente os moderadores que contribuiram de fato para o primeiro FEMUG-SC.
