### PR TITLE
Adicionando o Código de Conduta direto no repositório.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "codigo-de-conduta"]
-	path = codigo-de-conduta
-	url = https://github.com/fnando/Codigo-De-Conduta.git

--- a/CODIGO-DE-CONDUTA.md
+++ b/CODIGO-DE-CONDUTA.md
@@ -1,0 +1,49 @@
+
+# Código de Conduta
+
+O grupo de discussão deve ser um lugar seguro e convidativo para pessoas independentemente de:
+
+- Gênero, identidade de gênero ou expressão de gênero
+- Orientação sexual
+- Restrições físicas
+- Aparência física (incluindo, mas não limitado, ao tamanho do corpo)
+- Raça e/ou etnia
+- Idade
+- Religião ou a falta dela
+- Escolha de tecnologias
+
+Como membro deste grupo, você concorda que:
+
+* Nós somos, coletivamente e individualmente, comprometidos com a segurança e inclusão.
+* Nós adotamos a política de tolerância zero para assédio, perseguições ou discriminações.
+* Nós respeitamos os limites, identidade e privacidade das pessoas.
+* Nós nos abstemos de usar linguagem que possa ser considerada opressiva, como comentários sexistas, racistas, homofóbicos, transfóbicos, classistas ou que discrimine pessoas com qualquer tipo de deficiência, mas este Código de Conduta não está limitado a apenas estes.
+* Nós evitamos tópicos ofensivos como forma de humor.
+* Nós evitamos tópicos que fogem ao escopo do grupo, como conteúdo político.
+
+Nós trabalhamos ativamente para:
+
+* Ser uma comunidade segura.
+* Cultivar uma rede de suporte e encorajamento para todos.
+* Encorajar variadas formas de expressão de maneira responsável.
+
+Nós condenamos:
+
+* Perseguição, _doxxing_ (investigar a vida de uma pessoa sem autorização) ou publicações indevidas de informações privadas.
+* Ameaças e assédio de qualquer tipo.
+* Qualquer comportamento que comprometa a segurança dos demais membros.
+
+**Essas atitudes NÃO SÃO CORRETAS.** Se você não concorda com estas regras, por favor, cancele sua inscrição neste grupo.
+
+O desrespeito às regras desta comunidade, descritas nesse documento, acarretará em consequências:
+
+- Publicações que não estiverem de acordo com este Código de Conduta serão removidas.
+- Cabe aos administradores decidir se você será removido temporariamente ou permanentemente deste grupo.
+
+**Se você sofrer algum tipo de abuso, assédio, discriminação, ou se sentir inseguro, fale com um administrador. Se o administrador for a pessoa que você quer reportar, fale com outro administrador.**
+
+*A posição de administrador é para fins de moderação imparcial; eles não vão moderar ou editar o conteúdo postado pelos membros do grupo para outras finalidades ou por motivos estritamente pessoais.*
+
+--
+
+*Esse texto é um documento em constante edição, e pode ser alterado no futuro.* Código de conduta baseado em: https://github.com/fnando/codigo-de-conduta e https://github.com/AndroidDevBR/Codigo-De-Conduta

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Trata-se de um evento para pessoas interessadas em aprender, evoluir e dividir c
 
 ## Código de Conduta
 
-É importante destacar que o FEMUG (e todos os capítulos) contam com um [Código de Conduta](https://github.com/fnando/Codigo-De-Conduta). O mesmo DEVE ser levado a sério por membros, moderadores e adminitradores dos encontros, levando em consideração sempre o bem estar e ambiente inclusivo e diverso que visamos ter.
+É importante destacar que o FEMUG (e todos os capítulos) contam com um [Código de Conduta](CODIGO-DE-CONDUTA.md). O mesmo DEVE ser levado a sério por membros, moderadores e adminitradores dos encontros, levando em consideração sempre o bem estar e ambiente inclusivo e diverso que visamos ter.
 
 ## A escolha do nome
 


### PR DESCRIPTION
Mantendo o arquivo do código de conduta diretamente no repositório facilita a
referência ao seu conteúdo e remove a dependência do repositório externo.